### PR TITLE
changed grid spacing

### DIFF
--- a/examples/HeatEquation/BackwardEuler.jl
+++ b/examples/HeatEquation/BackwardEuler.jl
@@ -10,8 +10,8 @@ function HeatEquation()
     nc   = (x=nc.x+0, y=nc.y+0)
     nv   = (x=nv.x+0, y=nv.y+0)
     Δ    = (x=(xlim.max-xlim.min)/nc.x, y=(ylim.max-ylim.min)/nc.y)
-    x    = (c=LinRange(xlim.min-Δ.x/2, xlim.max+Δ.x/2, nc.x), v=LinRange(xlim.min-Δ.x, xlim.max+Δ.x, nv.x))
-    y    = (c=LinRange(ylim.min-Δ.y/2, ylim.max+Δ.y/2, nc.y), v=LinRange(ylim.min-Δ.y, ylim.max+Δ.y, nv.y))
+    x    = (c=LinRange(xlim.min+Δ.x/2, xlim.max-Δ.x/2, nc.x), v=LinRange(xlim.min, xlim.max, nv.x))
+    y    = (c=LinRange(ylim.min+Δ.y/2, ylim.max-Δ.y/2, nc.y), v=LinRange(ylim.min, ylim.max, nv.y))
     # Time domain
     nt   = 500
     t    = 0.

--- a/examples/HeatEquation/ForwardEuler.jl
+++ b/examples/HeatEquation/ForwardEuler.jl
@@ -10,8 +10,8 @@ function HeatEquation()
     nc   = (x=nc.x+0, y=nc.y+0)
     nv   = (x=nv.x+0, y=nv.y+0)
     Δ    = (x=(xlim.max-xlim.min)/nc.x, y=(ylim.max-ylim.min)/nc.y)
-    x    = (c=LinRange(xlim.min-Δ.x/2, xlim.max+Δ.x/2, nc.x), v=LinRange(xlim.min-Δ.x, xlim.max+Δ.x, nv.x))
-    y    = (c=LinRange(ylim.min-Δ.y/2, ylim.max+Δ.y/2, nc.y), v=LinRange(ylim.min-Δ.y, ylim.max+Δ.y, nv.y))
+    x    = (c=LinRange(xlim.min+Δ.x/2, xlim.max-Δ.x/2, nc.x), v=LinRange(xlim.min, xlim.max, nv.x))
+    y    = (c=LinRange(ylim.min+Δ.y/2, ylim.max-Δ.y/2, nc.y), v=LinRange(ylim.min, ylim.max, nv.y))
     # Time domain
     nt   = 400
     t    = 0.


### PR DESCRIPTION
@tduretz: Following your script, I tried to create a figure of the staggered grid for the diffusion equation (also for the lecture). Thereby, I realized, that you defined the grid in an odd way. You set xlim and ylim within the model domain. Thus, the spacing of x and y, for both the centroid and the vertices coordinates, is not equal $\Delta$ x and $\Delta$ y (I checked it with `diff(x.c)` and `diff(x.v)` in julia). 

I modified the spacing of x and y such that xlim.min, xlim.max and ylim.min, ylim.max define the vertical and horizontal boundaries of the model domain (see figure below). Now, the error is decreased significantly, and its pattern is different as well.  I think the figure is correct regarding the nodes and such. 

![Diffusion_Grid](https://github.com/user-attachments/assets/6c4cb469-0c9e-4e99-b999-73aee1ea0a9f)
gray shaded area - Modelling domain
Red Circle - $T, \rho, c_p, H$
Grey Circle - "Ghost" temperature nodes
Blue x - $q_x, k_x, \frac{\partial T}{\partial x}$
Green square - $q_y, k_y, \frac{\partial T}{\partial y}$
