### PR TITLE
Bump version to v0.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GeoModBox"
 uuid = "e210ae48-618e-410f-9a4d-7c1c87986529"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Lukas Fuchs <fuchs@geophysik.uni-frankfurt.de>"]
 
 [deps]


### PR DESCRIPTION
This PR updates the GeoModBox.jl package version from v0.1.0 to v0.1.1 in preparation for the patch release.

The release includes the recently merged threading fixes for 2-D tracer routines, improving compatibility with Julia 1.12 and environments using separate default and interactive thread pools, including Google Colab.

The updated implementation has been tested successfully with Julia using 1 and 4 threads and in Google Colab.